### PR TITLE
Menu item crud

### DIFF
--- a/CodeMonkeys.CMS.Public.Shared/Data/ApplicationDbContext.cs
+++ b/CodeMonkeys.CMS.Public.Shared/Data/ApplicationDbContext.cs
@@ -27,6 +27,7 @@ namespace CodeMonkeys.CMS.Public.Shared.Data
         public DbSet<ContentItem> ContentItems => Set<ContentItem>();
         public DbSet<Section> Sections => Set<Section>();
         public DbSet<Menu> Menus => Set<Menu>();
+        public DbSet<MenuItem> MenuItems => Set<MenuItem>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/CodeMonkeys.CMS.Public.Shared/Migrations/20241025143423_access-menu-items.Designer.cs
+++ b/CodeMonkeys.CMS.Public.Shared/Migrations/20241025143423_access-menu-items.Designer.cs
@@ -4,6 +4,7 @@ using CodeMonkeys.CMS.Public.Shared.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CodeMonkeys.CMS.Public.Shared.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241025143423_access-menu-items")]
+    partial class accessmenuitems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CodeMonkeys.CMS.Public.Shared/Migrations/20241025143423_access-menu-items.cs
+++ b/CodeMonkeys.CMS.Public.Shared/Migrations/20241025143423_access-menu-items.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CodeMonkeys.CMS.Public.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class accessmenuitems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MenuItem_Menus_MenuId",
+                table: "MenuItem");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MenuItem_Pages_WebPageId",
+                table: "MenuItem");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_MenuItem",
+                table: "MenuItem");
+
+            migrationBuilder.RenameTable(
+                name: "MenuItem",
+                newName: "MenuItems");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_MenuItem_WebPageId",
+                table: "MenuItems",
+                newName: "IX_MenuItems_WebPageId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_MenuItem_MenuId",
+                table: "MenuItems",
+                newName: "IX_MenuItems_MenuId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_MenuItems",
+                table: "MenuItems",
+                column: "MenuItemId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MenuItems_Menus_MenuId",
+                table: "MenuItems",
+                column: "MenuId",
+                principalTable: "Menus",
+                principalColumn: "MenuId",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MenuItems_Pages_WebPageId",
+                table: "MenuItems",
+                column: "WebPageId",
+                principalTable: "Pages",
+                principalColumn: "WebPageId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MenuItems_Menus_MenuId",
+                table: "MenuItems");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MenuItems_Pages_WebPageId",
+                table: "MenuItems");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_MenuItems",
+                table: "MenuItems");
+
+            migrationBuilder.RenameTable(
+                name: "MenuItems",
+                newName: "MenuItem");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_MenuItems_WebPageId",
+                table: "MenuItem",
+                newName: "IX_MenuItem_WebPageId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_MenuItems_MenuId",
+                table: "MenuItem",
+                newName: "IX_MenuItem_MenuId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_MenuItem",
+                table: "MenuItem",
+                column: "MenuItemId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MenuItem_Menus_MenuId",
+                table: "MenuItem",
+                column: "MenuId",
+                principalTable: "Menus",
+                principalColumn: "MenuId",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MenuItem_Pages_WebPageId",
+                table: "MenuItem",
+                column: "WebPageId",
+                principalTable: "Pages",
+                principalColumn: "WebPageId",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/CodeMonkeys.CMS.Public.Shared/Repository/IMenuRepository.cs
+++ b/CodeMonkeys.CMS.Public.Shared/Repository/IMenuRepository.cs
@@ -1,4 +1,8 @@
-﻿using CodeMonkeys.CMS.Public.Shared.Entities;
+﻿using AutoMapper;
+using CodeMonkeys.CMS.Public.Shared.Data;
+using CodeMonkeys.CMS.Public.Shared.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace CodeMonkeys.CMS.Public.Shared.Repository
 {
@@ -6,7 +10,8 @@ namespace CodeMonkeys.CMS.Public.Shared.Repository
     {
         Task AddAsync(Menu menu);
         Task AddMenuItemAsync(MenuItem menuItem);
-        Task DeleteMenuAsync(int menuId);
+        Task DeleteMenuItemAsync(int menuItemId);
+        Task DeleteMenuAsync(int menuItemId);
         Task<Menu?> GetMenuAsync(int menuId);
         Task<IEnumerable<Menu>> GetMenusBySiteIdAsync(int siteId);
         Task UpdateMenuAsync(Menu menu);

--- a/CodeMonkeys.CMS.Public.Shared/Repository/MenuRepository.cs
+++ b/CodeMonkeys.CMS.Public.Shared/Repository/MenuRepository.cs
@@ -50,6 +50,25 @@ namespace CodeMonkeys.CMS.Public.Shared.Repository
             }
         }
 
+        public async Task DeleteMenuItemAsync(int menuItemId)
+        {
+            using (ApplicationDbContext context = GetContext())
+            {
+                try
+                {
+                    MenuItem? menuItem = await context.MenuItems.FindAsync(menuItemId);
+                    if (menuItem == null) throw new InvalidOperationException($"No menu item with number{menuItemId} found.");
+                    context.MenuItems.Remove(menuItem);
+                    await context.SaveChangesAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to delete a menu item ");
+                    throw new RepositoryException("Failed to delete a menu item", ex);
+                }
+            }
+        }
+
         public Task<Menu?> GetMenuAsync(int menuId) => throw new NotImplementedException();
         public async Task<IEnumerable<Menu>> GetMenusBySiteIdAsync(int siteId)
         {

--- a/CodeMonkeys.CMS.Public.Shared/Services/IMenuService.cs
+++ b/CodeMonkeys.CMS.Public.Shared/Services/IMenuService.cs
@@ -10,5 +10,6 @@ namespace CodeMonkeys.CMS.Public.Shared.Services
         Task<IEnumerable<Menu>> GetMenusBySiteIdAsync(int siteId);
         Task UpdateMenuAsync(Menu menu);
         Task DeleteMenuAsync(int menuId);
+        Task DeleteMenuItemAsync(int menuItemId);
     }
 }

--- a/CodeMonkeys.CMS.Public.Shared/Services/MenuService.cs
+++ b/CodeMonkeys.CMS.Public.Shared/Services/MenuService.cs
@@ -47,5 +47,10 @@ namespace CodeMonkeys.CMS.Public.Shared.Services
         {
             await _repository.DeleteMenuAsync(menuId);
         }
+
+        public async Task DeleteMenuItemAsync(int menuItemId)
+        {
+            await _repository.DeleteMenuItemAsync(menuItemId);
+        }
     }
 }

--- a/CodeMonkeys.CMS.Public/Components/Pages/Sites/Menus/ManageMenus.razor
+++ b/CodeMonkeys.CMS.Public/Components/Pages/Sites/Menus/ManageMenus.razor
@@ -49,6 +49,7 @@
                                 <div class="menus-card-actions">
                                     <button class="btn btn-primary" @onclick="async () => await OpenMenuDialogAsync(menu.MenuId)">Rename menu</button>
                                     <button class="btn btn-danger" @onclick="async () => await OpenDeleteMenuDialogAsync(menu.MenuId)">Delete menu</button>
+                                    <button class="btn btn-primary" @onclick="async () => await OpenMenuItemDialogAsync(menu.MenuId)">Add a menu item</button>
                                     <!--
                                     <button class="btn btn-primary" @onclick="async () => await AddOrUpdatePageAsync(webPage.WebPageId)">Edit page title</button>
                                     <button class="btn btn-secondary" @onclick="async () => await EditContentsAsync(webPage.WebPageId)">Edit contents</button>
@@ -84,6 +85,22 @@
         Are you sure you want to delete the menu @(menuToDelete?.Name ?? "")?
     </ConfirmationDialog>
 
+    <ConfirmationDialog @ref="MenuItemDialog" Title="@MenuItemDialogTitle" ConfirmationButtonText=@MenuItemDialogConfirmationText CancelButtonText="Cancel" OnCancel="() => MenuItemDialog.Hide()" OnConfirm="() => SaveMenuItemDialogContents()">
+        <EditForm Model="@menuItemModel">
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+            <StatusMessage Message="@ErrorMessage" />
+            <div class="form-floating mb-3">
+                <InputSelect id="landing_page" @bind-Value="menuItemModel.WebPageId" class="form-control">
+                    @foreach ((int key, string pageName) in PageOptions)
+                    {
+                        <option value="@key">@pageName</option>
+                    }
+                </InputSelect>
+            </div>
+        </EditForm>
+    </ConfirmationDialog>
+
 </UserViewer>
 
 @code {
@@ -93,11 +110,17 @@
     public List<Menu>? Menus { get; set; }
     private ConfirmationDialog? MenuDialog { get; set; }
     private ConfirmationDialog? MenuDeleteDialog { get; set; }
+    private ConfirmationDialog? MenuItemDialog { get; set; }
     private string MenuDialogConfirmationText { get; set; }
     private string MenuDialogTitle { get; set; }
+    private string MenuItemDialogConfirmationText { get; set; }
+    private string MenuItemDialogTitle { get; set; }
     private MenuModel menuModel = new();
     private Menu menuToDelete;
+    private MenuItemModel menuItemModel = new();
+    private Dictionary<int, string> PageOptions = new() { { NoPageChosen, "None" } };
 
+    private const int NoPageChosen = -1;
 
     protected override async Task OnInitializedAsync()
     {
@@ -107,6 +130,10 @@
         if (Site == null)
         {
             Logger.LogWarning($"Site for user with ID '{User!.Id}' not found");
+        }
+        else
+        {
+            foreach (WebPage page in Site.Pages) PageOptions.Add(page.WebPageId, page.Title);
         }
         Menus = (await MenuService.GetMenusBySiteIdAsync(siteId)).ToList();
     }
@@ -124,7 +151,7 @@
             Menu? menu = Menus.Where(m => m.MenuId == menuId).FirstOrDefault();
             if (menu == null)
             {
-                ErrorMessage = "Page not found";
+                ErrorMessage = "Menu not found";
                 return Task.CompletedTask;
             }
             menuModel = new()
@@ -137,6 +164,34 @@
         }
 
         MenuDialog.Show();
+        return Task.CompletedTask;
+    }
+    public Task OpenMenuItemDialogAsync(int menuId, int? menuItemId = null)
+    {
+        if (menuItemId == null)
+        {
+            menuItemModel = new(){MenuId = menuId};
+            MenuItemDialogTitle = "Add Menu Item";
+            MenuItemDialogConfirmationText = "Add";
+        }
+        else
+        {
+            MenuItem? item = Menus?.Find(m => m.MenuId == menuId)?.Items.Where(m => m.MenuItemId == menuItemId).FirstOrDefault();
+            if (item == null)
+            {
+                ErrorMessage = "Menu item not found";
+                return Task.CompletedTask;
+            }
+            menuItemModel = new()
+                {
+                    MenuId = menuId,
+                    WebPageId = item.MenuId
+                };
+            MenuItemDialogTitle = "Edit Menu Item";
+            MenuItemDialogConfirmationText = "Update";
+        }
+
+        MenuItemDialog.Show();
         return Task.CompletedTask;
     }
 
@@ -158,6 +213,23 @@
             menu.Name = menuModel.Name;
             await MenuService.UpdateMenuAsync(menu);
         }
+    }
+
+    public async Task SaveMenuItemDialogContents()
+    {
+        Menu menu = Menus.Find(m => m.MenuId == menuItemModel.MenuId);
+        WebPage? webPage = Site.Pages.FirstOrDefault(p => p.WebPageId == menuItemModel.WebPageId);
+        if (webPage == null) return;
+        if(menuItemModel.MenuItemId == null)
+        {
+            menu.Items.Add(new MenuItem() { WebPage = webPage });
+        }
+        else
+        {
+            MenuItem? menuItem = menu.Items.FirstOrDefault(i => i.MenuItemId == menuItemModel.MenuItemId);
+            menuItem.WebPage = webPage;
+        }
+        await MenuService.UpdateMenuAsync(menu);
     }
 
     public Task OpenDeleteMenuDialogAsync(int menuId)
@@ -185,5 +257,12 @@
     {
         public int? MenuID { get; set; } = null;
         public string Name { get; set; } = string.Empty;
+    }
+
+    protected sealed class MenuItemModel
+    {
+        public int? MenuItemId { get; set; } = null;
+        public int? MenuId {get; set; } = null;
+        public int WebPageId { get; set; } = NoPageChosen;
     }
 }

--- a/CodeMonkeys.CMS.Public/Components/Pages/Sites/Menus/ManageMenus.razor
+++ b/CodeMonkeys.CMS.Public/Components/Pages/Sites/Menus/ManageMenus.razor
@@ -41,7 +41,9 @@
                                             @foreach (MenuItem item in menu.Items)
                                             {
                                                 <!--Not using rows, because I cannot get rows to work in this environment.-->
-                                                <div class="col-12">@item.WebPage.Title<button class="btn btn-primary" @onclick="async () => await OpenMenuItemDialogAsync(menu.MenuId, item.MenuItemId)">Edit</button></div>
+                                                <div class="col-12">@item.WebPage.Title
+                                                    <button class="btn btn-primary" @onclick="async () => await OpenMenuItemDialogAsync(menu.MenuId, item.MenuItemId)">Edit</button>
+                                                    <button class="btn btn-danger" @onclick="async () => await OpenDeleteMenuItemDialogAsync(item.MenuId, item.MenuItemId)">Delete</button></div>
                                             }
                                         </div>
                                     </div>
@@ -101,6 +103,10 @@
         </EditForm>
     </ConfirmationDialog>
 
+    <ConfirmationDialog @ref="MenuItemDeleteDialog" Title="Delete Menu" ConfirmationButtonText="Delete" CancelButtonText="Cancel" OnCancel="() => MenuItemDeleteDialog.Hide()" OnConfirm="DeleteMenuItem">
+        Are you sure you want to delete the menu item?
+    </ConfirmationDialog>
+
 </UserViewer>
 
 @code {
@@ -111,12 +117,14 @@
     private ConfirmationDialog? MenuDialog { get; set; }
     private ConfirmationDialog? MenuDeleteDialog { get; set; }
     private ConfirmationDialog? MenuItemDialog { get; set; }
+    private ConfirmationDialog? MenuItemDeleteDialog { get; set; }
     private string MenuDialogConfirmationText { get; set; }
     private string MenuDialogTitle { get; set; }
     private string MenuItemDialogConfirmationText { get; set; }
     private string MenuItemDialogTitle { get; set; }
     private MenuModel menuModel = new();
     private Menu menuToDelete;
+    private MenuItem menuItemToDelete;
     private MenuItemModel menuItemModel = new();
     private Dictionary<int, string> PageOptions = new() { { NoPageChosen, "None" } };
 
@@ -247,11 +255,44 @@
         return Task.CompletedTask;
     }
 
+    public Task OpenDeleteMenuItemDialogAsync(int menuId, int menuItemId)
+    {
+        Menu? menu = Menus.Where(m => m.MenuId == menuId).FirstOrDefault();
+        if (menu == null)
+        {
+            ErrorMessage = "Menu not found";
+            return Task.CompletedTask;
+        }
+        MenuItem? menuItem = menu.Items.ToList().Where(i => i.MenuItemId ==menuItemId).FirstOrDefault();
+        if (menuItem == null)
+        {
+            ErrorMessage = "Menu Item not found";
+            return Task.CompletedTask;
+        }
+        menuItemToDelete = menuItem;
+        MenuItemDeleteDialog.Show();
+        return Task.CompletedTask;
+    }
+
     public async Task DeleteMenu()
     {
         await MenuService.DeleteMenuAsync(menuToDelete.MenuId);
         Menus.RemoveAll(m => m.MenuId == menuToDelete.MenuId);
         MenuDeleteDialog.Hide();
+    }
+
+    public async Task DeleteMenuItem()
+    {
+        Menu? menu = Menus.Where(m => m.MenuId == menuItemToDelete.MenuId).FirstOrDefault();
+        if (menu == null)
+        {
+            ErrorMessage = "Menu not found";
+            return;
+        }
+        menu.Items.Remove(menuItemToDelete);
+        await MenuService.DeleteMenuItemAsync(menuItemToDelete.MenuItemId);
+
+        MenuItemDeleteDialog.Hide();
     }
 
 

--- a/CodeMonkeys.CMS.Public/Components/Pages/Sites/Menus/ManageMenus.razor
+++ b/CodeMonkeys.CMS.Public/Components/Pages/Sites/Menus/ManageMenus.razor
@@ -37,7 +37,13 @@
                                 </div>
                                 <div class="menus-card-body">
                                     <div class="menus-empty-box bg-light" style="height: 150px;">
-                                        <!-- Additional content can go here -->
+                                        <div class="container" style="overflow-y:scroll; height: 120px" >
+                                            @foreach (MenuItem item in menu.Items)
+                                            {
+                                                <!--Not using rows, because I cannot get rows to work in this environment.-->
+                                                <div class="col-12" >@item.WebPage.Title</div>
+                                            }
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="menus-card-actions">

--- a/CodeMonkeys.CMS.Public/Components/Pages/Sites/Menus/ManageMenus.razor
+++ b/CodeMonkeys.CMS.Public/Components/Pages/Sites/Menus/ManageMenus.razor
@@ -41,7 +41,7 @@
                                             @foreach (MenuItem item in menu.Items)
                                             {
                                                 <!--Not using rows, because I cannot get rows to work in this environment.-->
-                                                <div class="col-12" >@item.WebPage.Title</div>
+                                                <div class="col-12">@item.WebPage.Title<button class="btn btn-primary" @onclick="async () => await OpenMenuItemDialogAsync(menu.MenuId, item.MenuItemId)">Edit</button></div>
                                             }
                                         </div>
                                     </div>
@@ -184,8 +184,9 @@
             }
             menuItemModel = new()
                 {
+                    MenuItemId = item.MenuItemId,
                     MenuId = menuId,
-                    WebPageId = item.MenuId
+                    WebPageId = item.WebPageId
                 };
             MenuItemDialogTitle = "Edit Menu Item";
             MenuItemDialogConfirmationText = "Update";
@@ -228,6 +229,7 @@
         {
             MenuItem? menuItem = menu.Items.FirstOrDefault(i => i.MenuItemId == menuItemModel.MenuItemId);
             menuItem.WebPage = webPage;
+            menuItem.WebPageId = webPage.WebPageId;
         }
         await MenuService.UpdateMenuAsync(menu);
     }


### PR DESCRIPTION
Varning: Innehåller en databasmigration för att ge direkt tillgång till MenuItem-tabellen. (Att anropa context.Menus.Update med ett menyobjekt med tom Items-lista resulterar tydligen inte i ett databastillstånd där menyns MenuItems är borttagna.)

Om det här inte är det sätt som databasmigrationer i Azure ska hanteras på så föreställer jag mig att branchen bör anpassas till rätt sätt innan den mergas.

Jag tycker därtill att HTML-representationen av menyposterna är djupt otillfredsställande, men allt jag har försökt göra åt den saken har misslyckats.